### PR TITLE
Add compatible flux implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ A list of community-built React Native contributions
 
 - https://github.com/ecomfe/react-native-cn
 
+## Compatible Flux Implementation
+
+- https://github.com/lazywei/fluxxor/tree/react-native
+- https://github.com/brentvatne/flux-util
+- https://github.com/facebook/flux
+
 ## Pull Requests Welcome!
 
 I'd like to have an exhaustive list here


### PR DESCRIPTION
I'm not sure if this is suitable. However, I found a lot of flux implementations are not working on RN by default. Here are some implementations that can work smoothly on RN.
If needed, I can create a repo for example of flux + RN, and make another PR. How do you think?
Thanks.
