### PR TITLE
Add iBeacon library

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ A list of community-built React Native contributions
 
 - SQLite: https://github.com/almost/react-native-sqlite
 
+### Location-based services
+
+- iBeacon: https://github.com/geniuxconsulting/react-native-ibeacon
+
 ## Apps
 
 - https://github.com/iSimar/HackerNews-React-Native


### PR DESCRIPTION
I created a new category called "Location-based services" where I added the iBeacon library. Feel free to change it if you don't think it fits there.
